### PR TITLE
Change the scope to test

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -8,13 +8,16 @@ val defaultProjectSettings = Defaults.coreDefaultSettings ++ Seq(
   )
 )
 
+val testDependencies = Seq(
+  // https://mvnrepository.com/artifact/org.scalatest/scalatest_2.11
+  "org.scalatest" %% "scalatest" % "3.0.0" % "test"
+)
+
 val freeTask = Project(
   id = "free-task",
   base = file(""),
   settings = defaultProjectSettings
-).settings(libraryDependencies ++= Seq(
-  // https://mvnrepository.com/artifact/org.scalatest/scalatest_2.11
-  "org.scalatest" %% "scalatest" % "3.0.0",
+).settings(libraryDependencies ++= testDependencies ++ Seq(
   // https://mvnrepository.com/artifact/org.scalaz/scalaz-core_2.11
   "org.scalaz" %% "scalaz-core" % "7.2.6"
 ))
@@ -26,7 +29,7 @@ val freeTaskExample = Project(
 ).dependsOn(
   freeTask,
   ProjectRef(uri("git://github.com/gakuzzzz/free-scalikejdbc.git#b2622a9ab5aefbda775d3ef3a9ac4f431008523f"), "core")
-).settings(libraryDependencies ++= Seq(
+).settings(libraryDependencies ++= testDependencies ++ Seq(
   // https://mvnrepository.com/artifact/org.scalatest/scalatest_2.11
   "org.scalikejdbc" %% "scalikejdbc" % "2.4.2",
   // https://mvnrepository.com/artifact/com.h2database/h2


### PR DESCRIPTION
It seems that scalikejdbc-test doesn't support scalatest 3.x and the following error occurs
when scalikejdbc.scalatest.AutoRollback is used with org.scalatest.fixture.FlatSpec:

class A needs to be abstract, since method withFixture in trait TestSuite of type
(test: A.this.OneArgTest)org.scalatest.Outcome is not defined.

This might be caused by the scope of `scalatest` in libraryDependencis is not `"test"`.