### PR TITLE
EntityStore#Access を型パラメーターではなくAbstract Typeに変更

### DIFF
--- a/example/src/main/scala/com/evaluni/txn_example/domain/store/EntityStores.scala
+++ b/example/src/main/scala/com/evaluni/txn_example/domain/store/EntityStores.scala
@@ -2,7 +2,9 @@ package com.evaluni.txn_example.domain.store
 
 import scala.language.higherKinds
 
-trait EntityStores[M[_], Access[_]] {
+trait EntityStores[M[_]] {
+
+  type Access[a]
 
   implicit def readonlyMainStore: Access[MainStore.R]
   implicit def writableMainStore: Access[MainStore.W]

--- a/example/src/main/scala/com/evaluni/txn_example/infra/RdbEntityStores.scala
+++ b/example/src/main/scala/com/evaluni/txn_example/infra/RdbEntityStores.scala
@@ -5,7 +5,9 @@ import com.evaluni.txn_example.domain.store.MainStore
 import com.evaluni.txn_example.domain.store.Txn
 import scala.util.Try
 
-class RdbEntityStores(handler: EntityIOHandler) extends EntityStores[Try, Rdb.Access] {
+class RdbEntityStores(handler: EntityIOHandler) extends EntityStores[Try] {
+
+  override type Access[a] = Rdb.Access[a]
 
   import Rdb._
 


### PR DESCRIPTION
`Access` が型パラメーターだと
 - 利用側で具象型が規定する `Access` と互換の型を指示しなくてはいけないので `EntityStore` という抽象型のまま扱いづらい
 - そもそも `Access` の値は、ある `EntityStore` のインスタンス上のインターフェイスを行き来するのみなので、利用サイドに型を特定させる意味がない
