### PR TITLE
Add a covariance version of TxnT for convenience

### DIFF
--- a/example/src/main/scala/com/evaluni/txn_example/domain/store/EntityOp.scala
+++ b/example/src/main/scala/com/evaluni/txn_example/domain/store/EntityOp.scala
@@ -1,12 +1,12 @@
 package com.evaluni.txn_example.domain.store
 
+import com.evaluni.freetask.CovariantFree
 import scala.language.implicitConversions
-import scalaz.Free
 
 trait EntityOp[A]
 
 object EntityOp {
 
-  implicit final def send[A](a: EntityOp[A]): Txn[Any, A] = Txn.liftMT[EntityIO, A](Free.liftF(a))
+  implicit final def send[A](a: EntityOp[A]): Txn[Any, A] = Txn.liftMT[EntityIO, A](CovariantFree(a))
 
 }

--- a/example/src/main/scala/com/evaluni/txn_example/domain/store/package.scala
+++ b/example/src/main/scala/com/evaluni/txn_example/domain/store/package.scala
@@ -1,19 +1,19 @@
 package com.evaluni.txn_example.domain
 
-import com.evaluni.freetask.TxnT
-import com.evaluni.freetask.TxnTFunctions
+import com.evaluni.freetask.CovariantFree
+import com.evaluni.freetask.CovariantTxnT
+import com.evaluni.freetask.CovariantTxnTFunctions
 import scala.language.reflectiveCalls
 import scalaz.Coyoneda
-import scalaz.Free
 
 package object store {
 
-  type EntityIO[A] = Free[EntityOp, A]
+  type EntityIO[+A] = CovariantFree[EntityOp, A]
 
-  implicit val entityIOMonad = Free.freeMonad[({type f[x] = Coyoneda[EntityOp, x]})#f]
+  implicit val entityIOMonad = CovariantFree.monad[({type f[x] = Coyoneda[EntityOp, x]})#f]
 
-  type Txn[-R, A] = TxnT[EntityIO, R, A]
+  type Txn[-R, +A] = CovariantTxnT[EntityIO, R, A]
 
-  def Txn = TxnTFunctions
+  object Txn extends CovariantTxnTFunctions
 
 }

--- a/example/src/main/scala/com/evaluni/txn_example/infra/EntityIOHandler.scala
+++ b/example/src/main/scala/com/evaluni/txn_example/infra/EntityIOHandler.scala
@@ -1,5 +1,6 @@
 package com.evaluni.txn_example.infra
 
+import com.evaluni.freetask.CovariantFree
 import com.evaluni.txn_example.domain.RoleHandler
 import com.evaluni.txn_example.domain.UserHandler
 import com.evaluni.txn_example.domain.store.EntityOp
@@ -22,6 +23,9 @@ trait EntityIOHandler {
   import SampleDatabase.IO
 
   def handle[A](op: EntityOp[A]): Option[IO[A]]
+
+
+  final def convert[A](next: CovariantFree[EntityOp, A]): IO[A] = convert(next.get[A])
 
   final def convert[A](next: Free[EntityOp, A]): IO[A] =
     next.foldMap(new (EntityOp ~> IO) {

--- a/example/src/main/scala/com/evaluni/txn_example/infra/EntityIOHandler.scala
+++ b/example/src/main/scala/com/evaluni/txn_example/infra/EntityIOHandler.scala
@@ -25,7 +25,7 @@ trait EntityIOHandler {
   def handle[A](op: EntityOp[A]): Option[IO[A]]
 
 
-  final def convert[A](next: CovariantFree[EntityOp, A]): IO[A] = convert(next.get[A])
+  final def convert[A](next: CovariantFree[EntityOp, A]): IO[A] = convert(next.cast[A])
 
   final def convert[A](next: Free[EntityOp, A]): IO[A] =
     next.foldMap(new (EntityOp ~> IO) {

--- a/example/src/main/scala/com/evaluni/txn_example/service/UserService.scala
+++ b/example/src/main/scala/com/evaluni/txn_example/service/UserService.scala
@@ -1,6 +1,5 @@
 package com.evaluni.txn_example.service
 
-import com.evaluni.freetask.TxnT
 import com.evaluni.txn_example.domain.RoleRepository
 import com.evaluni.txn_example.domain.UserId
 import com.evaluni.txn_example.domain.UserRepository
@@ -22,12 +21,10 @@ trait UserService extends UsesSampleDatabaseEntityStore with UsesDatabaseExecuti
   ): Future[Either[CreateUserError, UserId]] = invoke {
     UserRepository.findByName(name).flatMap {
       case Some(_) =>
-        Txn(Left(CreateUserError.DuplicatedName)): TxnT[EntityIO, MainStore.W, Either[CreateUserError, UserId]]
-      //TODO remove type declare
+        Txn(Left(CreateUserError.DuplicatedName))
       case None =>
         UserRepository.create(name, age).flatMap { userId =>
-          RoleRepository.create(userId, isAdmin).map(_ => Right(userId)): TxnT[EntityIO, MainStore.W, Either[CreateUserError, UserId]]
-          //TODO remove type declare
+          RoleRepository.create(userId, isAdmin).map(_ => Right(userId))
         }
     }
   }

--- a/src/main/scala/com/evaluni/freetask/CovariantFree.scala
+++ b/src/main/scala/com/evaluni/freetask/CovariantFree.scala
@@ -1,0 +1,25 @@
+package com.evaluni.freetask
+
+import scala.language.higherKinds
+import scalaz.Free
+import scalaz.Monad
+
+class CovariantFree[F[_], +A] private (private val raw: Free[F, _ <: A]) {
+  def get[B >: A]: Free[F, B] = raw.map(e => e: B)
+}
+
+object CovariantFree {
+
+  implicit def monad[F[_]]: Monad[({ type f[a] = CovariantFree[F, a] })#f] = new Monad[({type f[a] = CovariantFree[F, a]})#f] {
+
+    override def bind[A, B](fa: CovariantFree[F, A])(f: A => CovariantFree[F, B]): CovariantFree[F, B] =
+      new CovariantFree(
+        fa.get[A].flatMap { a => f(a).get[B] }
+      )
+
+    override def point[A](a: => A): CovariantFree[F, A] =
+      new CovariantFree(Free.freeMonad[F].point(a))
+  }
+
+  def apply[F[_], A](fa: F[A]): CovariantFree[F, A] = new CovariantFree(Free.liftF(fa))
+}

--- a/src/main/scala/com/evaluni/freetask/CovariantFree.scala
+++ b/src/main/scala/com/evaluni/freetask/CovariantFree.scala
@@ -5,7 +5,7 @@ import scalaz.Free
 import scalaz.Monad
 
 class CovariantFree[F[_], +A] private (private val raw: Free[F, _ <: A]) {
-  def get[B >: A]: Free[F, B] = raw.map(e => e: B)
+  def cast[B >: A]: Free[F, B] = raw.map(e => e: B)
 }
 
 object CovariantFree {
@@ -14,7 +14,7 @@ object CovariantFree {
 
     override def bind[A, B](fa: CovariantFree[F, A])(f: A => CovariantFree[F, B]): CovariantFree[F, B] =
       new CovariantFree(
-        fa.get[A].flatMap { a => f(a).get[B] }
+        fa.cast[A].flatMap { a => f(a).cast[B] }
       )
 
     override def point[A](a: => A): CovariantFree[F, A] =

--- a/src/main/scala/com/evaluni/freetask/CovariantTxnT.scala
+++ b/src/main/scala/com/evaluni/freetask/CovariantTxnT.scala
@@ -1,0 +1,35 @@
+package com.evaluni.freetask
+
+import scala.language.higherKinds
+import scalaz.Monad
+import scalaz.syntax.all._
+
+class CovariantTxnT[M[+_], -R, +A] private[freetask] (val raw: M[A]) {
+
+  import CovariantTxnTFunctions._
+
+  def flatMap[R2 <: R, B](f: A => CovariantTxnT[M, R2, B])(implicit M: Monad[M]): CovariantTxnT[M, R2, B] =
+    liftMT(raw flatMap f.andThen(_.raw))
+
+  def map[B](f: A => B)(implicit M: Monad[M]): CovariantTxnT[M, R, B] = flatMap(a => apply(f(a)))
+
+}
+
+trait CovariantTxnTFunctions { self =>
+
+  def liftMT[M[+_], A](ma: M[A]): CovariantTxnT[M, Any, A] = new CovariantTxnT[M, Any, A](ma)
+
+  def apply[M[+_], A](a: => A)(implicit M: Monad[M]): CovariantTxnT[M, Any, A] = liftMT(M.point(a))
+
+  implicit def monad[M[+_], R]
+  (implicit M: Monad[M]): Monad[({ type f[a] = CovariantTxnT[M, R, a] })#f] = new Monad[({ type f[a] = CovariantTxnT[M, R, a] })#f] {
+
+    override def point[A](a: => A): CovariantTxnT[M, R, A] = self[M, A](a)
+
+    override def bind[A, B](fa: CovariantTxnT[M, R, A])(f: A => CovariantTxnT[M, R, B]): CovariantTxnT[M, R, B] = fa flatMap f
+
+  }
+
+}
+
+object CovariantTxnTFunctions extends CovariantTxnTFunctions


### PR DESCRIPTION
`TxnT[-R, A]` はインバリアントなため、その計算結果に共変なコンテナー型(for example `Either`, `Seq`)などが来ると `flatMap` などで式の型を明記しないと複雑なコンパイルエラーが出てしまっていました。このPRはその問題を迂回するためのものです。

As `TxnT[-R, A]` is invariant type, when the result type of `TxnT` is a covariant container type, Scala compiler generates too complex compilation errors unless annotate the type of expressions explicitly for scala compiler. You can avoid the issue with the changes in this PR.